### PR TITLE
Mejorar la performance de proccon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/gosuri/uitable v0.0.0-20160404203958-36ee7e946282 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.11.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/hydrogen18/stoppableListener v0.0.0-20151210151943-dadc9ccc400c
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac // indirect
@@ -50,7 +51,6 @@ require (
 	github.com/lunixbochs/struc v0.0.0-20180408203800-02e4c2afbb2a
 	github.com/lxc/lxd v0.0.0-20200330183600-518f06676866
 	github.com/mailru/easyjson v0.7.6
-	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mattn/goveralls v0.0.2
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
@@ -79,7 +79,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.7.0
 	github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c
 	github.com/tebeka/go2xunit v1.4.10
 	github.com/tebeka/selenium v0.0.0-20170314201507-657e45ec600f
@@ -89,9 +89,16 @@ require (
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 // indirect
 	github.com/weaveworks/tcptracer-bpf v0.0.0-20170817155301-e080bd747dc6
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0
+	go.opentelemetry.io/otel v0.20.0
+	go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0
+	go.opentelemetry.io/otel/sdk v0.20.0
+	go.opentelemetry.io/otel/trace v0.20.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/fsnotify/fsnotify.v1 v1.0.0-20180110053347-c2828203cd70
 	gopkg.in/macaroon-bakery.v2 v2.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/golangci/golangci-lint v1.18.0
 	github.com/gomatic/renderizer v1.0.1
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gopacket v1.1.17
 	github.com/gophercloud/gophercloud v0.13.0
 	github.com/gorilla/mux v1.8.0
@@ -89,11 +90,6 @@ require (
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df
 	github.com/voxelbrain/goptions v0.0.0-20180630082107-58cddc247ea2 // indirect
 	github.com/weaveworks/tcptracer-bpf v0.0.0-20170817155301-e080bd747dc6
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0
-	go.opentelemetry.io/otel v0.20.0
-	go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0
-	go.opentelemetry.io/otel/sdk v0.20.0
-	go.opentelemetry.io/otel/trace v0.20.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f

--- a/topology/probes/proccon/proccon_test.go
+++ b/topology/probes/proccon/proccon_test.go
@@ -2,7 +2,6 @@ package proccon
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1649,8 +1648,7 @@ func BenchmarkProcessMetricsSameNode(b *testing.B) {
 		})
 	}
 
-	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		p.processMetrics(ctx, metrics)
+		p.processMetrics(metrics)
 	}
 }

--- a/topology/probes/proccon/proccon_test.go
+++ b/topology/probes/proccon/proccon_test.go
@@ -203,7 +203,7 @@ func TestPresentServerCreateSoftwareToOthers(t *testing.T) {
 
 	givenServerName := "hostFoo"
 
-	serverNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	serverNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -287,7 +287,7 @@ func TestFillOthersSoftwareNode(t *testing.T) {
 
 	givenServerName := "hostFoo"
 
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -295,7 +295,7 @@ func TestFillOthersSoftwareNode(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -417,7 +417,7 @@ func TestMetricDateIsUsed(t *testing.T) {
 
 	givenServerName := "hostFoo"
 
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -425,7 +425,7 @@ func TestMetricDateIsUsed(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -501,7 +501,7 @@ func TestMultipleMetricsToOtherOnlyOneRevision(t *testing.T) {
 
 	givenServerName := "hostFoo"
 
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -509,7 +509,7 @@ func TestMultipleMetricsToOtherOnlyOneRevision(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -707,7 +707,7 @@ func TestMetricDateIsUsedWhenUpdating(t *testing.T) {
 
 	givenServerName := "hostFoo"
 
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -715,7 +715,7 @@ func TestMetricDateIsUsedWhenUpdating(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -802,7 +802,7 @@ func TestFillOthersSoftwareNodeWithConnPrefix(t *testing.T) {
 
 	givenServerName := "hostFoo"
 
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -810,7 +810,7 @@ func TestFillOthersSoftwareNodeWithConnPrefix(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -886,7 +886,7 @@ func TestNewMetricUpdateNetworkMetadata(t *testing.T) {
 	givenOthersSoftwareTCPConnections := []string{"1.2.3.4:80"}
 	givenOthersSoftwareListenEndpoints := []string{"192.168.0.1:22"}
 
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -894,7 +894,7 @@ func TestNewMetricUpdateNetworkMetadata(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -1014,7 +1014,7 @@ func TestAppendConnectionInfoToOthersSoftwareNode(t *testing.T) {
 	givenOthersSoftwareListenEndpoints := []string{"192.168.0.1:22", "10.0.1.1:22"}
 
 	p.graph.Lock()
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -1022,7 +1022,7 @@ func TestAppendConnectionInfoToOthersSoftwareNode(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenOtherNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenOtherNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 	})
@@ -1116,7 +1116,7 @@ func TestFillKnownSoftwareNode(t *testing.T) {
 	givenSoftwareListenEndpoints := []string{"192.168.0.1:5432", "10.0.1.1:5432"}
 
 	p.graph.Lock()
-	givenNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: givenServerName,
 		MetadataTypeKey: MetadataTypeServer,
 	})
@@ -1124,7 +1124,7 @@ func TestFillKnownSoftwareNode(t *testing.T) {
 		t.Errorf("Unable to create server %s", givenServerName)
 	}
 
-	givenSWNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	givenSWNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey:    givenSoftwareName,
 		MetadataTypeKey:    MetadataTypeSoftware,
 		MetadataCmdlineKey: cmdline,
@@ -1267,7 +1267,7 @@ func TestClearOldConnectionsKeepNewerConnections(t *testing.T) {
 	p := Probe{}
 	p.graph = newGraph(t)
 
-	software, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	software, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey: OthersSoftwareNode,
 		MetadataTypeKey: MetadataTypeSoftware,
 		MetadataTCPConnKey: &NetworkInfo{
@@ -1324,7 +1324,7 @@ func TestCleanTCPListenIfTCPConnIsInvalid(t *testing.T) {
 	p := Probe{}
 	p.graph = newGraph(t)
 
-	software, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	software, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey:    OthersSoftwareNode,
 		MetadataTypeKey:    MetadataTypeSoftware,
 		MetadataTCPConnKey: "",
@@ -1363,7 +1363,7 @@ func TestDoNotPanicIfInvalidTCPConnOrTCPListenDataType(t *testing.T) {
 	p := Probe{}
 	p.graph = newGraph(t)
 
-	software, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	software, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey:           OthersSoftwareNode,
 		MetadataTypeKey:           MetadataTypeSoftware,
 		MetadataTCPConnKey:        "",
@@ -1385,7 +1385,7 @@ func TestDoNotReturnErrorIfTCPConnOrTCPListenKeysDoesNotExists(t *testing.T) {
 	p := Probe{}
 	p.graph = newGraph(t)
 
-	softwareNoTCPConn, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	softwareNoTCPConn, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey:           OthersSoftwareNode,
 		MetadataTypeKey:           MetadataTypeSoftware,
 		MetadataListenEndpointKey: "",
@@ -1394,7 +1394,7 @@ func TestDoNotReturnErrorIfTCPConnOrTCPListenKeysDoesNotExists(t *testing.T) {
 		t.Error("Unable to create software others")
 	}
 
-	softwareNoTCPListen, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	softwareNoTCPListen, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey:    OthersSoftwareNode,
 		MetadataTypeKey:    MetadataTypeSoftware,
 		MetadataTCPConnKey: "",
@@ -1515,7 +1515,7 @@ func TestMigrateConnInfoFromOthersToKnownSoftwareNode(t *testing.T) {
 	// WHEN
 	// Create a software node for netcat linked to "hostFoo" server
 	netcatSoftwareName := "Netcat"
-	netcatNode, err := p.graph.NewNode(graph.GenID(), graph.Metadata{
+	netcatNode, err := p.newNode("host", graph.Metadata{
 		MetadataNameKey:    netcatSoftwareName,
 		MetadataTypeKey:    MetadataTypeSoftware,
 		MetadataCmdlineKey: metricSoftwareCmdline,
@@ -1611,112 +1611,46 @@ func generateProcInfoData(conn []string, metricTimestamp int64) NetworkInfo {
 	return ret
 }
 
-// TODO
-// Como testear que tengamos más o menos nodos en el grafo.
-// Con el tema del map para indexar, como gestionamos que no tengamos datos antiguos o hayan
-// aparecido datos nuevos.
-// Los child los metemos también en el map?
-//
-// BenchmarkProcessMetricSerial run processMetric() func with different number of nodes in the backend
-func BenchmarkProcessMetricSerial(b *testing.B) {
+// BenchmarkProcessMetricsSameNode replicate how this probe will receive the data.
+// Usually each POST will contain only metrics of the same host.
+func BenchmarkProcessMetricsSameNode(b *testing.B) {
 	p := Probe{}
 	p.graph = newGraph(b)
 
-	hostname := "foo"
+	metrics := []Metric{}
 
-	metric := Metric{
-		Name: "foo",
-		Time: MessagePackTime{
-			time: time.Now(),
-		},
-		Tags: map[string]string{
-			"tag1": "foo1",
-			"tag2": "foo2",
-		},
-		Fields: map[string]string{
-			"f1": "f1",
-			"f2": "f2",
-			"f3": "f3",
-		},
+	// Create nodes in the backend
+	for i := 1; i < 10000; i++ {
+		_, err := p.newNode("host", graph.Metadata{
+			MetadataNameKey: fmt.Sprintf("foo-%d", i),
+			MetadataTypeKey: MetadataTypeServer,
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Create an array of 1000 metrics of the same node (same tags.host)
+	for i := 0; i < 1000; i++ {
+		metrics = append(metrics, Metric{
+			Name: "tcp",
+			Time: MessagePackTime{
+				time: time.Now(),
+			},
+			Tags: map[string]string{
+				"host":    "foo",
+				"cmdline": fmt.Sprintf("foo-%d", i),
+			},
+			Fields: map[string]string{
+				"f1": "f1",
+				"f2": "f2",
+				"f3": "f3",
+			},
+		})
 	}
 
 	ctx := context.Background()
-
-	for j := 0; j <= 5; j++ {
-		numberOfNodes := j * 2000
-		p.graph = newGraph(b)
-
-		// Add numberOfNodes to the backend
-		for i := 1; i < numberOfNodes; i++ {
-			_, err := p.newNode(hostname, graph.Metadata{
-				MetadataNameKey: fmt.Sprintf("%s-%d-%d", hostname, i, j),
-				MetadataTypeKey: MetadataTypeServer,
-			})
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		b.Run(fmt.Sprintf("number of nodes: %v", numberOfNodes), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				others := map[*graph.Node][]Metric{}
-				p.processMetric(ctx, metric, others)
-			}
-		})
-	}
-}
-
-// BenchmarkProcessMetricParallel run processMetric() func in parallel with different
-// number of nodes in the backend
-func BenchmarkProcessMetricParallel(b *testing.B) {
-	p := Probe{}
-
-	hostname := "foo"
-
-	metric := Metric{
-		Name: "foo",
-		Time: MessagePackTime{
-			time: time.Now(),
-		},
-		Tags: map[string]string{
-			"tag1": "foo1",
-			"tag2": "foo2",
-		},
-		Fields: map[string]string{
-			"f1": "f1",
-			"f2": "f2",
-			"f3": "f3",
-		},
-	}
-
-	ctx := context.Background()
-
-	for j := 0; j <= 5; j++ {
-		numberOfNodes := j * 2000
-		p.graph = newGraph(b)
-
-		// Add numberOfNodes to the backend
-		for i := 1; i < numberOfNodes; i++ {
-			_, err := p.newNode(hostname, graph.Metadata{
-				MetadataNameKey: fmt.Sprintf("%s-%d-%d", hostname, i, j),
-				MetadataTypeKey: MetadataTypeServer,
-			})
-			if err != nil {
-				panic(err)
-			}
-		}
-
-		// Tests en paralelo
-
-		b.Run(fmt.Sprintf("number of nodes: %v", numberOfNodes), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				b.RunParallel(func(pb *testing.PB) {
-					for pb.Next() {
-						others := map[*graph.Node][]Metric{}
-						p.processMetric(ctx, metric, others)
-					}
-				})
-			}
-		})
+	for i := 0; i < b.N; i++ {
+		p.processMetrics(ctx, metrics)
 	}
 }


### PR DESCRIPTION
Cuando existen muchos nodos en el backend de Skydive, proccon comienza a generar un montón de locks largos debidos a la búsqueda de nodos tipo Server.

Modificamos la implementación usando el _truco_ de que cada server tenga un identificador que puede ser obtenido a partir de los metadatos (``Server__Nombre``).

Los commits describen mejor el problema, la implementación y resultados.