### PR TITLE
Añadidos step Events y Neighbors

### DIFF
--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -335,6 +335,7 @@ func NewServerFromConfig() (*Server, error) {
 	tr.AddTraversalExtension(ge.NewAscendantsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewNextHopTraversalExtension())
 	tr.AddTraversalExtension(ge.NewGroupTraversalExtension())
+	tr.AddTraversalExtension(ge.NewEventsTraversalExtension())
 
 	// new flow subscriber endpoints
 	flowSubscriberWSServer := ws.NewStructServer(config.NewWSServer(hub.HTTPServer(), "/ws/subscriber/flow", apiAuthBackend))

--- a/analyzer/server.go
+++ b/analyzer/server.go
@@ -333,6 +333,7 @@ func NewServerFromConfig() (*Server, error) {
 	tr.AddTraversalExtension(ge.NewSocketsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewDescendantsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewAscendantsTraversalExtension())
+	tr.AddTraversalExtension(ge.NewNeighborsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewNextHopTraversalExtension())
 	tr.AddTraversalExtension(ge.NewGroupTraversalExtension())
 	tr.AddTraversalExtension(ge.NewEventsTraversalExtension())

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/t-yuki/gocover-cobertura v0.0.0-20180217150009-aaee18c8195c
 	github.com/tebeka/go2xunit v1.4.10
 	github.com/tebeka/selenium v0.0.0-20170314201507-657e45ec600f
-	github.com/tinylib/msgp v1.1.0 // indirect
+	github.com/tinylib/msgp v1.1.0
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df

--- a/graffiti/graph/cachedbackend.go
+++ b/graffiti/graph/cachedbackend.go
@@ -99,6 +99,17 @@ func (c *CachedBackend) GetNode(i Identifier, t Context) []*Node {
 	return c.persistent.GetNode(i, t)
 }
 
+// GetNodesFromIDs retrieve the list of nodes for the list of identifiers from the cache within a time slice
+func (c *CachedBackend) GetNodesFromIDs(i []Identifier, t Context) []*Node {
+	mode := c.cacheMode.Load()
+
+	if t.TimeSlice == nil || mode == CacheOnlyMode || c.persistent == nil {
+		return c.memory.GetNodesFromIDs(i, t)
+	}
+
+	return c.persistent.GetNodesFromIDs(i, t)
+}
+
 // GetNodeEdges retrieve a list of edges from a node within a time slice, matching metadata
 func (c *CachedBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edges []*Edge) {
 	mode := c.cacheMode.Load()
@@ -108,6 +119,17 @@ func (c *CachedBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edge
 	}
 
 	return c.persistent.GetNodeEdges(n, t, m)
+}
+
+// GetNodesEdges return the list of all edges for a list of nodes within time slice, matching metadata
+func (c *CachedBackend) GetNodesEdges(n []*Node, t Context, m ElementMatcher) (edges []*Edge) {
+	mode := c.cacheMode.Load()
+
+	if t.TimeSlice == nil || mode == CacheOnlyMode || c.persistent == nil {
+		return c.memory.GetNodesEdges(n, t, m)
+	}
+
+	return c.persistent.GetNodesEdges(n, t, m)
 }
 
 // EdgeAdded add an edge in the cache

--- a/graffiti/graph/elasticsearch.go
+++ b/graffiti/graph/elasticsearch.go
@@ -87,6 +87,8 @@ const graphElementMapping = `
 const (
 	nodeType = "node"
 	edgeType = "edge"
+	// maxClauseCount limit the number of clauses in one query to ES
+	maxClauseCount = 512
 )
 
 // ElasticSearchBackend describes a persistent backend based on ElasticSearch
@@ -238,20 +240,34 @@ func (b *ElasticSearchBackend) GetNode(i Identifier, t Context) []*Node {
 
 // GetNodesFromIDs get the list of nodes for the list of identifiers within a time slice
 func (b *ElasticSearchBackend) GetNodesFromIDs(identifiersList []Identifier, t Context) []*Node {
-	identifiersFilter := []*filters.Filter{}
-	for _, i := range identifiersList {
-		identifiersFilter = append(identifiersFilter, filters.NewTermStringFilter("ID", string(i)))
+	if len(identifiersList) == 0 {
+		return []*Node{}
 	}
-	identifiersORFilter := filters.NewOrFilter(identifiersFilter...)
 
-	nodes := b.searchNodes(&TimedSearchQuery{
-		SearchQuery: filters.SearchQuery{
-			Filter: identifiersORFilter,
-			Sort:   true,
-			SortBy: "Revision",
-		},
-		TimeFilter: getTimeFilter(t.TimeSlice),
-	})
+	// ES default max number of clauses is set by default to 1024
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html
+	// Group queries in a maximum of half of the max.
+	// Other filters (time), will be also in the query.
+	identifiersBatch := batchIdentifiers(identifiersList, maxClauseCount)
+
+	nodes := []*Node{}
+
+	for _, idList := range identifiersBatch {
+		identifiersFilter := []*filters.Filter{}
+		for _, i := range idList {
+			identifiersFilter = append(identifiersFilter, filters.NewTermStringFilter("ID", string(i)))
+		}
+		identifiersORFilter := filters.NewOrFilter(identifiersFilter...)
+
+		nodes = append(nodes, b.searchNodes(&TimedSearchQuery{
+			SearchQuery: filters.SearchQuery{
+				Filter: identifiersORFilter,
+				Sort:   true,
+				SortBy: "Revision",
+			},
+			TimeFilter: getTimeFilter(t.TimeSlice),
+		})...)
+	}
 
 	if len(nodes) > 1 && t.TimePoint {
 		return []*Node{nodes[len(nodes)-1]}
@@ -570,32 +586,43 @@ func (b *ElasticSearchBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher
 
 // GetNodesEdges return the list of all edges for a list of nodes within time slice
 func (b *ElasticSearchBackend) GetNodesEdges(nodeList []*Node, t Context, m ElementMatcher) (edges []*Edge) {
-	var filter *filters.Filter
-	if m != nil {
-		f, err := m.Filter()
-		if err != nil {
-			return []*Edge{}
+	if len(nodeList) == 0 {
+		return []*Edge{}
+	}
+
+	// See comment at GetNodesFromIDs
+	// As we are adding two operations per item, make small batches
+	nodesBatch := batchNodes(nodeList, maxClauseCount/2)
+
+	for _, nList := range nodesBatch {
+		var filter *filters.Filter
+		if m != nil {
+			f, err := m.Filter()
+			if err != nil {
+				return []*Edge{}
+			}
+			filter = f
 		}
-		filter = f
-	}
 
-	var searchQuery filters.SearchQuery
-	if !t.TimePoint {
-		searchQuery = filters.SearchQuery{Sort: true, SortBy: "UpdatedAt"}
-	}
+		var searchQuery filters.SearchQuery
+		if !t.TimePoint {
+			searchQuery = filters.SearchQuery{Sort: true, SortBy: "UpdatedAt"}
+		}
 
-	nodesFilter := []*filters.Filter{}
-	for _, n := range nodeList {
-		nodesFilter = append(nodesFilter, filters.NewTermStringFilter("Parent", string(n.ID)))
-		nodesFilter = append(nodesFilter, filters.NewTermStringFilter("Child", string(n.ID)))
-	}
-	searchQuery.Filter = filters.NewOrFilter(nodesFilter...)
+		nodesFilter := []*filters.Filter{}
+		for _, n := range nList {
+			nodesFilter = append(nodesFilter, filters.NewTermStringFilter("Parent", string(n.ID)))
+			nodesFilter = append(nodesFilter, filters.NewTermStringFilter("Child", string(n.ID)))
+		}
+		searchQuery.Filter = filters.NewOrFilter(nodesFilter...)
 
-	edges = b.searchEdges(&TimedSearchQuery{
-		SearchQuery:    searchQuery,
-		TimeFilter:     getTimeFilter(t.TimeSlice),
-		MetadataFilter: filter,
-	})
+		edges = append(edges, b.searchEdges(&TimedSearchQuery{
+			SearchQuery:    searchQuery,
+			TimeFilter:     getTimeFilter(t.TimeSlice),
+			MetadataFilter: filter,
+		})...)
+
+	}
 
 	if len(edges) > 1 && t.TimePoint {
 		edges = dedupEdges(edges)
@@ -744,4 +771,27 @@ func NewElasticSearchBackendFromConfig(cfg es.Config, extraDynamicTemplates map[
 	}
 
 	return newElasticSearchBackendFromClient(client, cfg.IndexPrefix, liveIndex, archiveIndex, logger), nil
+}
+
+func batchNodes(items []*Node, batchSize int) [][]*Node {
+	batches := make([][]*Node, 0, (len(items)+batchSize-1)/batchSize)
+
+	for batchSize < len(items) {
+		items, batches = items[batchSize:], append(batches, items[0:batchSize:batchSize])
+	}
+	batches = append(batches, items)
+
+	return batches
+
+}
+
+func batchIdentifiers(items []Identifier, batchSize int) [][]Identifier {
+	batches := make([][]Identifier, 0, (len(items)+batchSize-1)/batchSize)
+
+	for batchSize < len(items) {
+		items, batches = items[batchSize:], append(batches, items[0:batchSize:batchSize])
+	}
+	batches = append(batches, items)
+
+	return batches
 }

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -1217,6 +1217,9 @@ func (g *Graph) GetNode(i Identifier) *Node {
 
 // GetNodesFromIDs returns a list of nodes from a list of identifiers
 func (g *Graph) GetNodesFromIDs(i []Identifier) []*Node {
+	if len(i) == 0 {
+		return []*Node{}
+	}
 	return g.backend.GetNodesFromIDs(i, g.context)
 }
 
@@ -1407,6 +1410,9 @@ func (g *Graph) GetNodeEdges(n *Node, m ElementMatcher) []*Edge {
 
 // GetNodesEdges returns the list with all edges for a list of nodes
 func (g *Graph) GetNodesEdges(n []*Node, m ElementMatcher) []*Edge {
+	if len(n) == 0 {
+		return []*Edge{}
+	}
 	return g.backend.GetNodesEdges(n, g.context, m)
 }
 

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -1213,6 +1213,11 @@ func (g *Graph) GetNode(i Identifier) *Node {
 	return nil
 }
 
+// GetNodeAll from Identifier, all revisions
+func (g *Graph) GetNodeAll(i Identifier) []*Node {
+	return g.backend.GetNode(i, g.context)
+}
+
 // CreateNode returns a new node not bound to a graph
 func CreateNode(i Identifier, m Metadata, t Time, h string, o string) *Node {
 	n := &Node{

--- a/graffiti/graph/graph.go
+++ b/graffiti/graph/graph.go
@@ -106,7 +106,9 @@ type Backend interface {
 	NodeAdded(n *Node) error
 	NodeDeleted(n *Node) error
 	GetNode(i Identifier, at Context) []*Node
+	GetNodesFromIDs(i []Identifier, at Context) []*Node
 	GetNodeEdges(n *Node, at Context, m ElementMatcher) []*Edge
+	GetNodesEdges(n []*Node, at Context, m ElementMatcher) []*Edge
 
 	EdgeAdded(e *Edge) error
 	EdgeDeleted(e *Edge) error
@@ -1213,6 +1215,11 @@ func (g *Graph) GetNode(i Identifier) *Node {
 	return nil
 }
 
+// GetNodesFromIDs returns a list of nodes from a list of identifiers
+func (g *Graph) GetNodesFromIDs(i []Identifier) []*Node {
+	return g.backend.GetNodesFromIDs(i, g.context)
+}
+
 // GetNodeAll from Identifier, all revisions
 func (g *Graph) GetNodeAll(i Identifier) []*Node {
 	return g.backend.GetNode(i, g.context)
@@ -1396,6 +1403,11 @@ func (g *Graph) GetEdgeNodes(e *Edge, parentMetadata, childMetadata ElementMatch
 // GetNodeEdges returns a list of edges of a node
 func (g *Graph) GetNodeEdges(n *Node, m ElementMatcher) []*Edge {
 	return g.backend.GetNodeEdges(n, g.context, m)
+}
+
+// GetNodesEdges returns the list with all edges for a list of nodes
+func (g *Graph) GetNodesEdges(n []*Node, m ElementMatcher) []*Edge {
+	return g.backend.GetNodesEdges(n, g.context, m)
 }
 
 func (g *Graph) String() string {

--- a/graffiti/graph/memory.go
+++ b/graffiti/graph/memory.go
@@ -138,6 +138,17 @@ func (m *MemoryBackend) GetNode(i Identifier, t Context) []*Node {
 	return nil
 }
 
+// GetNodesFromIDs from the graph backend
+func (m *MemoryBackend) GetNodesFromIDs(identifiersList []Identifier, t Context) []*Node {
+	nodes := []*Node{}
+	for _, i := range identifiersList {
+		if n, ok := m.nodes[i]; ok {
+			nodes = append(nodes, n.Node)
+		}
+	}
+	return nodes
+}
+
 // GetNodeEdges returns a list of edges of a node
 func (m *MemoryBackend) GetNodeEdges(n *Node, t Context, meta ElementMatcher) []*Edge {
 	edges := []*Edge{}
@@ -146,6 +157,22 @@ func (m *MemoryBackend) GetNodeEdges(n *Node, t Context, meta ElementMatcher) []
 		for _, e := range n.edges {
 			if e.MatchMetadata(meta) {
 				edges = append(edges, e.Edge)
+			}
+		}
+	}
+
+	return edges
+}
+
+// GetNodesEdges returns the list of edges for a list of nodes
+func (m *MemoryBackend) GetNodesEdges(nodeList []*Node, t Context, meta ElementMatcher) []*Edge {
+	edges := []*Edge{}
+	for _, n := range nodeList {
+		if n, ok := m.nodes[n.ID]; ok {
+			for _, e := range n.edges {
+				if e.MatchMetadata(meta) {
+					edges = append(edges, e.Edge)
+				}
 			}
 		}
 	}

--- a/graffiti/graph/orientdb.go
+++ b/graffiti/graph/orientdb.go
@@ -229,10 +229,44 @@ func (o *OrientDBBackend) GetNode(i Identifier, t Context) (nodes []*Node) {
 	return o.searchNodes(t, query)
 }
 
+func (o *OrientDBBackend) GetNodesFromIDs(identifiersList []Identifier, t Context) (nodes []*Node) {
+	query := orientdb.FilterToExpression(getTimeFilter(t.TimeSlice), nil)
+	query += fmt.Sprintf(" AND (")
+	for i, id := range identifiersList {
+		if i == len(identifiersList)-1 {
+			query += fmt.Sprintf(" ID = '%s') ORDER BY Revision", id)
+		} else {
+			query += fmt.Sprintf(" ID = '%s' OR", id)
+		}
+	}
+
+	if t.TimePoint {
+		query += " DESC LIMIT 1"
+	}
+	return o.searchNodes(t, query)
+}
+
 // GetNodeEdges returns a list of a node edges within time slice
 func (o *OrientDBBackend) GetNodeEdges(n *Node, t Context, m ElementMatcher) (edges []*Edge) {
 	query := orientdb.FilterToExpression(getTimeFilter(t.TimeSlice), nil)
 	query += fmt.Sprintf(" AND (Parent = '%s' OR Child = '%s')", n.ID, n.ID)
+	if metadataQuery := metadataToOrientDBSelectString(m); metadataQuery != "" {
+		query += " AND " + metadataQuery
+	}
+	return o.searchEdges(t, query)
+}
+
+// GetNodesEdges returns a list of a node edges within time slice
+func (o *OrientDBBackend) GetNodesEdges(nodeList []*Node, t Context, m ElementMatcher) (edges []*Edge) {
+	query := orientdb.FilterToExpression(getTimeFilter(t.TimeSlice), nil)
+	query += fmt.Sprintf(" AND (")
+	for i, n := range nodeList {
+		if i == len(nodeList)-1 {
+			query += fmt.Sprintf(" Parent = '%s' OR Child = '%s')", n.ID, n.ID)
+		} else {
+			query += fmt.Sprintf(" Parent = '%s' OR Child = '%s' OR", n.ID, n.ID)
+		}
+	}
 	if metadataQuery := metadataToOrientDBSelectString(m); metadataQuery != "" {
 		query += " AND " + metadataQuery
 	}

--- a/graffiti/graph/traversal/traversal.go
+++ b/graffiti/graph/traversal/traversal.go
@@ -1414,14 +1414,12 @@ func (tv *GraphTraversalV) SubGraph(ctx StepContext, s ...interface{}) *GraphTra
 
 	// then insert edges, ignore edge insert error since one of the linked node couldn't be part
 	// of the SubGraph
-	for _, n := range tv.nodes {
-		edges := tv.GraphTraversal.Graph.GetNodeEdges(n, nil)
-		for _, e := range edges {
-			switch err := memory.EdgeAdded(e); err {
-			case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:
-			default:
-				return &GraphTraversal{error: fmt.Errorf("Error while adding edge to SubGraph: %s", err)}
-			}
+	edges := tv.GraphTraversal.Graph.GetNodesEdges(tv.nodes, nil)
+	for _, e := range edges {
+		switch err := memory.EdgeAdded(e); err {
+		case nil, graph.ErrParentNotFound, graph.ErrChildNotFound, graph.ErrEdgeConflict:
+		default:
+			return &GraphTraversal{error: fmt.Errorf("Error while adding edge to SubGraph: %s", err)}
 		}
 	}
 

--- a/gremlin/traversal/events.go
+++ b/gremlin/traversal/events.go
@@ -2,6 +2,8 @@ package traversal
 
 import (
 	"reflect"
+	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/skydive-project/skydive/graffiti/graph"
@@ -14,11 +16,23 @@ type EventsTraversalExtension struct {
 	EventsToken traversal.Token
 }
 
-// EventsGremlinTraversalStep describes the Events gremlin traversal step
+// EventsGremlinTraversalStep step aggregates events from different revisions of the nodes into a new metadata key.
+// This step should be used with a presistant backend, so it can access previous revisions of the nodes.
+// To use this step we should select a metadata key (first parameter), where the events will be read from.
+// Inside this Metadata.Key events should have the format map[string]interface{}.
+// The second parameter is the metadata key where all the events will be aggregated.
+// The aggregation will with the format: map[string][]interface{}.
+// All events with the same key in the map will be joined in an slice.
+// To use this step we can use a graph with a time period context, eg: G.At(1479899809,3600).V().Events('A','B').
+// Or we can define the time period in the step: G.V().Events('A','B',1500000000,1500099999).
+// Note that in this case we define the start and end time, while in "At" is start time and duration.
+// In both cases, Events step will use the nodes given by the previous step.
 type EventsGremlinTraversalStep struct {
 	traversal.GremlinTraversalContext
 	EventKey    string
 	EventAggKey string
+	StartTime   time.Time
+	EndTime     time.Time
 }
 
 // NewEventsTraversalExtension returns a new graph traversal extension
@@ -47,6 +61,7 @@ func (e *EventsTraversalExtension) ParseStep(t traversal.Token, p traversal.Grem
 	}
 
 	var eventKey, eventAggKey string
+	var startTime, endTime time.Time
 	var ok bool
 
 	switch len(p.Params) {
@@ -59,14 +74,35 @@ func (e *EventsTraversalExtension) ParseStep(t traversal.Token, p traversal.Grem
 		if !ok {
 			return nil, errors.New("Events second parameter have to be a string")
 		}
+	case 4:
+		eventKey, ok = p.Params[0].(string)
+		if !ok {
+			return nil, errors.New("Events first parameter have to be a string")
+		}
+		eventAggKey, ok = p.Params[1].(string)
+		if !ok {
+			return nil, errors.New("Events second parameter have to be a string")
+		}
+		startTimeUnixEpoch, ok := p.Params[2].(int64)
+		if !ok {
+			return nil, errors.New("Events third parameter have to be a int (unix epoch time)")
+		}
+		startTime = time.Unix(startTimeUnixEpoch, 0)
+		endTimeUnixEpoch, ok := p.Params[3].(int64)
+		if !ok {
+			return nil, errors.New("Events fourth parameter have to be a int (unix epoch time)")
+		}
+		endTime = time.Unix(endTimeUnixEpoch, 0)
 	default:
-		return nil, errors.New("Events parameter must have two parameters")
+		return nil, errors.New("Events parameter must have two or four parameters (OriginKey, DestinationKey, StartTime, EndTime)")
 	}
 
 	return &EventsGremlinTraversalStep{
 		GremlinTraversalContext: p,
 		EventKey:                eventKey,
 		EventAggKey:             eventAggKey,
+		StartTime:               startTime,
+		EndTime:                 endTime,
 	}, nil
 }
 
@@ -74,7 +110,8 @@ func (e *EventsTraversalExtension) ParseStep(t traversal.Token, p traversal.Grem
 func (s *EventsGremlinTraversalStep) Exec(last traversal.GraphTraversalStep) (traversal.GraphTraversalStep, error) {
 	switch tv := last.(type) {
 	case *traversal.GraphTraversalV:
-		return InterfaceEvents(s.StepContext, tv, s.EventKey, s.EventAggKey), nil
+		return s.InterfaceEvents(tv)
+
 	}
 	return nil, traversal.ErrExecutionError
 }
@@ -93,16 +130,43 @@ func (s *EventsGremlinTraversalStep) Context() *traversal.GremlinTraversalContex
 // input nodes and put them into the newest node for each id into Metadata.aggKey.
 // Events are groupped based on its key. See mergedEvents for an example.
 // All output nodes will have Metadata.aggKey defined (empty or not).
-func InterfaceEvents(ctx traversal.StepContext, tv *traversal.GraphTraversalV, key, aggKey string) traversal.GraphTraversalStep {
-	it := ctx.PaginationRange.Iterator()
-	//gslice := tv.GraphTraversal.Graph.GetContext().TimeSlice
+func (s *EventsGremlinTraversalStep) InterfaceEvents(tv *traversal.GraphTraversalV) (traversal.GraphTraversalStep, error) {
+	it := s.StepContext.PaginationRange.Iterator()
+
+	// If user has defined start/end time in the parameters, use that values instead of the ones comming with the graph
+	if !s.StartTime.IsZero() && !s.EndTime.IsZero() {
+		timeSlice := graph.NewTimeSlice(
+			graph.Time(s.StartTime).UnixMilli(),
+			graph.Time(s.EndTime).UnixMilli(),
+		)
+		userTimeSliceCtx := graph.Context{
+			TimeSlice: timeSlice,
+			TimePoint: true,
+		}
+
+		newGraph, err := tv.GraphTraversal.Graph.CloneWithContext(userTimeSliceCtx)
+		if err != nil {
+			return nil, err
+		}
+		tv.GraphTraversal.Graph = newGraph
+	}
 
 	tv.GraphTraversal.RLock()
 	defer tv.GraphTraversal.RUnlock()
 
+	// uniqNodes store the latest node for each node identifier
 	uniqNodes := map[graph.Identifier]*graph.Node{}
+	uniqNodesLock := sync.Mutex{}
+
 	// events accumulate the events for each node id
 	events := map[graph.Identifier]map[string][]interface{}{}
+	eventsLock := sync.Mutex{}
+
+	// Limit the number of goroutines querying the backend at the same time
+	// A high number of concurrent queries makes ElasticSearch slower.
+	backendLimitConcurrentCalls := make(chan struct{}, 40)
+
+	wg := sync.WaitGroup{}
 
 	for _, node := range tv.GetNodes() {
 		// TODO afecta la paginación a esta función? Cuando se usa esta paginación?
@@ -110,32 +174,47 @@ func InterfaceEvents(ctx traversal.StepContext, tv *traversal.GraphTraversalV, k
 			break
 		}
 
-		// Get all revisions for this node
-		revisionNodes := tv.GraphTraversal.Graph.GetNodeAll(node.ID)
+		// Spawn a different goroutine for each node to speed up this function
+		// Elasticsearch client is thread safe.
+		wg.Add(1)
+		go func(nodeID graph.Identifier) {
+			defer wg.Done()
 
-		// Store only the most recent nodes
-		for _, rNode := range revisionNodes {
-			storedNode, ok := uniqNodes[rNode.ID]
-			if !ok {
-				uniqNodes[rNode.ID] = rNode
-			} else {
-				if storedNode.Revision < rNode.Revision {
+			// Get all revisions for this node
+			backendLimitConcurrentCalls <- struct{}{}
+			revisionNodes := tv.GraphTraversal.Graph.GetNodeAll(nodeID)
+			<-backendLimitConcurrentCalls
+
+			// Store only the most recent nodes
+			for _, rNode := range revisionNodes {
+				uniqNodesLock.Lock()
+				storedNode, ok := uniqNodes[rNode.ID]
+				if !ok {
 					uniqNodes[rNode.ID] = rNode
+				} else {
+					if storedNode.Revision < rNode.Revision {
+						uniqNodes[rNode.ID] = rNode
+					}
 				}
-			}
+				uniqNodesLock.Unlock()
 
-			// Store events from all revisions into the "events" variable
-			events[rNode.ID] = mergeEvents(rNode, key, events[rNode.ID])
-		}
+				// Store events from all revisions into the "events" variable
+				eventsLock.Lock()
+				events[rNode.ID] = mergeEvents(rNode, s.EventKey, events[rNode.ID])
+				eventsLock.Unlock()
+			}
+		}(node.ID)
 	}
+
+	wg.Wait()
 
 	// Move the nodes from the uniqNodes map to an slice required by TraversalV
 	nodes := []*graph.Node{}
 	for id, n := range uniqNodes {
 		e, ok := events[id]
 		if ok {
-			// Set the stored node with the merge of Alarms from previous and current node
-			metadataSet := uniqNodes[id].Metadata.SetField(aggKey, e)
+			// Set the stored node with the merge of Events from previous and current node
+			metadataSet := uniqNodes[id].Metadata.SetField(s.EventAggKey, e)
 			if !metadataSet {
 				logging.GetLogger().Errorf("Unable to set events metadata for host %v", id)
 			}
@@ -144,7 +223,7 @@ func InterfaceEvents(ctx traversal.StepContext, tv *traversal.GraphTraversalV, k
 		nodes = append(nodes, n)
 	}
 
-	return traversal.NewGraphTraversalV(tv.GraphTraversal, nodes)
+	return traversal.NewGraphTraversalV(tv.GraphTraversal, nodes), nil
 }
 
 // mergeEvents return the merge of node.Key events with the ones already stored in nodeEvents

--- a/gremlin/traversal/events.go
+++ b/gremlin/traversal/events.go
@@ -1,0 +1,175 @@
+package traversal
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/graffiti/graph/traversal"
+	"github.com/skydive-project/skydive/graffiti/logging"
+)
+
+// EventsTraversalExtension describes a new extension to enhance the topology
+type EventsTraversalExtension struct {
+	EventsToken traversal.Token
+}
+
+// EventsGremlinTraversalStep describes the Events gremlin traversal step
+type EventsGremlinTraversalStep struct {
+	traversal.GremlinTraversalContext
+	EventKey    string
+	EventAggKey string
+}
+
+// NewEventsTraversalExtension returns a new graph traversal extension
+func NewEventsTraversalExtension() *EventsTraversalExtension {
+	return &EventsTraversalExtension{
+		EventsToken: traversalEventsToken,
+	}
+}
+
+// ScanIdent recognise the word associated with this step (in uppercase) and return a token
+// which represents it. Return true if it have found a match
+func (e *EventsTraversalExtension) ScanIdent(s string) (traversal.Token, bool) {
+	switch s {
+	case "EVENTS":
+		return e.EventsToken, true
+	}
+	return traversal.IDENT, false
+}
+
+// ParseStep generate a step for a given token, having in 'p' context and params
+func (e *EventsTraversalExtension) ParseStep(t traversal.Token, p traversal.GremlinTraversalContext) (traversal.GremlinTraversalStep, error) {
+	switch t {
+	case e.EventsToken:
+	default:
+		return nil, nil
+	}
+
+	var eventKey, eventAggKey string
+	var ok bool
+
+	switch len(p.Params) {
+	case 2:
+		eventKey, ok = p.Params[0].(string)
+		if !ok {
+			return nil, errors.New("Events first parameter have to be a string")
+		}
+		eventAggKey, ok = p.Params[1].(string)
+		if !ok {
+			return nil, errors.New("Events second parameter have to be a string")
+		}
+	default:
+		return nil, errors.New("Events parameter must have two parameters")
+	}
+
+	return &EventsGremlinTraversalStep{
+		GremlinTraversalContext: p,
+		EventKey:                eventKey,
+		EventAggKey:             eventAggKey,
+	}, nil
+}
+
+// Exec executes the events step
+func (s *EventsGremlinTraversalStep) Exec(last traversal.GraphTraversalStep) (traversal.GraphTraversalStep, error) {
+	switch tv := last.(type) {
+	case *traversal.GraphTraversalV:
+		return InterfaceEvents(s.StepContext, tv, s.EventKey, s.EventAggKey), nil
+	}
+	return nil, traversal.ErrExecutionError
+}
+
+// Reduce events step
+func (s *EventsGremlinTraversalStep) Reduce(next traversal.GremlinTraversalStep) (traversal.GremlinTraversalStep, error) {
+	return next, nil
+}
+
+// Context events step
+func (s *EventsGremlinTraversalStep) Context() *traversal.GremlinTraversalContext {
+	return &s.GremlinTraversalContext
+}
+
+// InterfaceEvents for each node id, group all the events stored in Metadata.key from the
+// input nodes and put them into the newest node for each id into Metadata.aggKey.
+// Events are groupped based on its key. See mergedEvents for an example.
+// All output nodes will have Metadata.aggKey defined (empty or not).
+func InterfaceEvents(ctx traversal.StepContext, tv *traversal.GraphTraversalV, key, aggKey string) traversal.GraphTraversalStep {
+	it := ctx.PaginationRange.Iterator()
+	//gslice := tv.GraphTraversal.Graph.GetContext().TimeSlice
+
+	tv.GraphTraversal.RLock()
+	defer tv.GraphTraversal.RUnlock()
+
+	uniqNodes := map[graph.Identifier]*graph.Node{}
+	// events accumulate the events for each node id
+	events := map[graph.Identifier]map[string][]interface{}{}
+
+	for _, newNode := range tv.GetNodes() {
+		// TODO afecta la paginación a esta función? Cuando se usa esta paginación?
+		if it.Done() {
+			break
+		}
+
+		// Store only the most recent nodes
+		storedNode, ok := uniqNodes[newNode.ID]
+		if !ok {
+			uniqNodes[newNode.ID] = newNode
+		} else {
+			if storedNode.Revision < newNode.Revision {
+				uniqNodes[newNode.ID] = newNode
+			}
+		}
+
+		// Store events from nodes into the "events" variable
+		events[newNode.ID] = mergeEvents(newNode, key, events[newNode.ID])
+	}
+
+	// Move the nodes from the uniqNodes map to an slice required by TraversalV
+	nodes := []*graph.Node{}
+	for id, n := range uniqNodes {
+		e, ok := events[id]
+		if ok {
+			// Set the stored node with the merge of Alarms from previous and current node
+			metadataSet := uniqNodes[id].Metadata.SetField(aggKey, e)
+			if !metadataSet {
+				logging.GetLogger().Errorf("Unable to set events metadata for host %v", id)
+			}
+		}
+
+		nodes = append(nodes, n)
+	}
+
+	return traversal.NewGraphTraversalV(tv.GraphTraversal, nodes)
+}
+
+// mergeEvents return the merge of node.Key events with the ones already stored in nodeEvents
+// Eg.:
+//   node:       Metadata.key: {"a":{x}, "b":{y}}
+//   nodeEvents:               {"a":{z}}
+//   return:     Metadata.key: {"a":[{x},{z}], "b":[{y}]}
+//
+// Ignore if Metadata.key has an invalid format.
+func mergeEvents(node *graph.Node, key string, nodeEvents map[string][]interface{}) map[string][]interface{} {
+	if nodeEvents == nil {
+		nodeEvents = map[string][]interface{}{}
+	}
+
+	n1EventsIface, n1Err := node.GetField(key)
+	if n1Err == nil {
+		// Ignore Metadata.key values with not a valid format
+		n1Events, _ := n1EventsIface.(map[string]interface{})
+	NODE_EVENTS:
+		for k, v := range n1Events {
+			// Do not append if the same event already exists
+			for _, storedEvent := range nodeEvents[k] {
+				if reflect.DeepEqual(storedEvent, v) {
+					continue NODE_EVENTS
+				}
+			}
+
+			nodeEvents[k] = append(nodeEvents[k], v)
+		}
+	}
+
+	return nodeEvents
+}

--- a/gremlin/traversal/events_test.go
+++ b/gremlin/traversal/events_test.go
@@ -29,6 +29,18 @@ func (b *FakeEventsGraphBackend) GetNode(i graph.Identifier, at graph.Context) [
 	return nodes
 }
 
+func (b *FakeEventsGraphBackend) GetNodesFromIDs(identifierList []graph.Identifier, at graph.Context) []*graph.Node {
+	nodes := []*graph.Node{}
+	for _, n := range b.Nodes {
+		for _, i := range identifierList {
+			if n.ID == i {
+				nodes = append(nodes, n)
+			}
+		}
+	}
+	return nodes
+}
+
 func TestMergeEventsNilNodeEvents(t *testing.T) {
 	key := "Events"
 

--- a/gremlin/traversal/events_test.go
+++ b/gremlin/traversal/events_test.go
@@ -1,0 +1,366 @@
+package traversal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/graffiti/graph/traversal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeEventsNilNodeEvents(t *testing.T) {
+	key := "Events"
+
+	metadataNode1 := graph.Metadata{key: map[string]interface{}{
+		"abc": map[string]string{"descr": "foo"},
+	}}
+	node := CreateNode("nodeA", metadataNode1, graph.TimeUTC(), 1)
+
+	nodeEventsAgg := mergeEvents(node, key, nil)
+
+	expected := map[string][]interface{}{
+		"abc": {
+			map[string]string{"descr": "foo"},
+		},
+	}
+
+	assert.Equal(t, expected, nodeEventsAgg)
+}
+
+func TestMergeEvents(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodesEvents []interface{}
+		expected    map[string][]interface{}
+	}{
+		{
+			name:     "no nodes",
+			expected: map[string][]interface{}{},
+		},
+		{
+			name: "one node",
+			nodesEvents: []interface{}{
+				map[string]interface{}{
+					"abc": map[string]string{"descr": "foo"},
+				}},
+			expected: map[string][]interface{}{
+				"abc": {
+					map[string]string{"descr": "foo"},
+				},
+			},
+		},
+		{
+			name: "two nodes, different keys",
+			nodesEvents: []interface{}{
+				map[string]interface{}{
+					"abc": map[string]string{"descr": "foo"},
+				},
+				map[string]interface{}{
+					"xyz": map[string]string{"descr": "bar"},
+				}},
+			expected: map[string][]interface{}{
+				"abc": {
+					map[string]string{"descr": "foo"},
+				},
+				"xyz": {
+					map[string]string{"descr": "bar"},
+				},
+			},
+		},
+		{
+			name: "two nodes, same keys",
+			nodesEvents: []interface{}{
+				map[string]interface{}{
+					"abc": map[string]string{"descr": "foo"},
+				},
+				map[string]interface{}{
+					"abc": map[string]string{"descr": "bar"},
+				}},
+			expected: map[string][]interface{}{
+				"abc": {
+					map[string]string{"descr": "foo"},
+					map[string]string{"descr": "bar"},
+				},
+			},
+		},
+		{
+			name: "two nodes, repeating one event, should be removed",
+			nodesEvents: []interface{}{
+				map[string]interface{}{
+					"abc": map[string]string{"descr": "foo"},
+				},
+				map[string]interface{}{
+					"abc": map[string]string{"descr": "foo"},
+					"xxx": map[string]string{"descr": "bar"},
+				}},
+			expected: map[string][]interface{}{
+				"abc": {
+					map[string]string{"descr": "foo"},
+				},
+				"xxx": {
+					map[string]string{"descr": "bar"},
+				},
+			},
+		},
+	}
+
+	key := "Events"
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nodeEventsAgg := map[string][]interface{}{}
+
+			for _, nodeEvents := range test.nodesEvents {
+				metadataNode1 := graph.Metadata{key: nodeEvents}
+				node := CreateNode("nodeA", metadataNode1, graph.TimeUTC(), 1)
+
+				nodeEventsAgg = mergeEvents(node, key, nodeEventsAgg)
+			}
+
+			assert.Equal(t, test.expected, nodeEventsAgg)
+		})
+	}
+}
+
+func TestInterfaceEvents(t *testing.T) {
+	tests := []struct {
+		name    string
+		InNodes []*graph.Node
+		key     string
+		aggKey  string
+		// Expected nodes
+		OutNodes []*graph.Node
+	}{
+		{
+			name: "no input nodes",
+		},
+		{
+			// Node passes the step without being modified
+			name:   "one input node without key defined",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{}, graph.Time(time.Unix(0, 0)), 1),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"EventsAgg": map[string][]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+		},
+		{
+			name:   "one input node with key defined but empty",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events":    map[string]interface{}{},
+					"EventsAgg": map[string][]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+		},
+		{
+			name:   "one input node with key defined and one alarm",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+					"EventsAgg": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "a"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+		},
+		{
+			name:   "two different input nodes with key defined and one alarm each one",
+			key:    "Events",
+			aggKey: "EventsAxx",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("B", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+					"EventsAxx": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "a"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("B", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+					"EventsAxx": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "a"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+			},
+		},
+		{
+			name:   "one node, with a previous version, both without key defined",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("A", graph.Metadata{}, graph.Time(time.Unix(0, 0)), 2),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"EventsAgg": map[string][]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+		},
+		{
+			name:   "one node, with a previous version, both with key defined but empty",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events":    map[string]interface{}{},
+					"EventsAgg": map[string][]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+		},
+		{
+			name:   "one node, with a previous version, both with key defined, same event different content",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "b"}},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "b"}},
+					"EventsAgg": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "a"},
+						map[string]interface{}{"desc": "b"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+		},
+		{
+			name:   "one node, with a previous version, first one without event, second one with event",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "b"}},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "b"}},
+					"EventsAgg": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "b"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+		},
+		{
+			name:   "one node, with a previous version, first one with event, second one without event",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+					"EventsAgg": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "a"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 2),
+			},
+		},
+		{
+			name:   "one node, with two previous versions, first with, second without, third with",
+			key:    "Events",
+			aggKey: "EventsAgg",
+			InNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "a"}},
+				}, graph.Time(time.Unix(0, 0)), 1),
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{},
+				}, graph.Time(time.Unix(0, 0)), 2),
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "c"}},
+				}, graph.Time(time.Unix(0, 0)), 3),
+			},
+			OutNodes: []*graph.Node{
+				CreateNode("A", graph.Metadata{
+					"Events": map[string]interface{}{"e1": map[string]interface{}{"desc": "c"}},
+					"EventsAgg": map[string][]interface{}{"e1": {
+						map[string]interface{}{"desc": "a"},
+						map[string]interface{}{"desc": "c"},
+					}},
+				}, graph.Time(time.Unix(0, 0)), 3),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := graph.NewMemoryBackend()
+			if err != nil {
+				t.Error(err.Error())
+			}
+			g := graph.NewGraph("testhost", b, "analyzer.testhost")
+
+			gt := traversal.NewGraphTraversal(g, false)
+			ctx := traversal.StepContext{}
+			tvIn := traversal.NewGraphTraversalV(gt, test.InNodes)
+
+			ts := InterfaceEvents(ctx, tvIn, test.key, test.aggKey)
+
+			tvOut, ok := ts.(*traversal.GraphTraversalV)
+			if !ok {
+				t.Errorf("Invalid GraphTraversal type")
+			}
+
+			assert.ElementsMatch(t, test.OutNodes, tvOut.GetNodes())
+		})
+	}
+}
+
+// CreateNode func to create nodes with a specific node revision
+func CreateNode(id string, m graph.Metadata, t graph.Time, revision int64) *graph.Node {
+	n := graph.CreateNode(graph.Identifier(id), m, t, "host", "orig")
+	n.Revision = revision
+	return n
+}

--- a/gremlin/traversal/neighbors.go
+++ b/gremlin/traversal/neighbors.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package traversal
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/skydive-project/skydive/graffiti/filters"
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/skydive-project/skydive/graffiti/graph/traversal"
+	"github.com/skydive-project/skydive/topology"
+)
+
+// NeighborsTraversalExtension describes a new extension to enhance the topology
+type NeighborsTraversalExtension struct {
+	NeighborsToken traversal.Token
+}
+
+// NeighborsGremlinTraversalStep rawpackets step
+type NeighborsGremlinTraversalStep struct {
+	context    traversal.GremlinTraversalContext
+	maxDepth   int64
+	edgeFilter graph.ElementMatcher
+}
+
+// NewNeighborsTraversalExtension returns a new graph traversal extension
+func NewNeighborsTraversalExtension() *NeighborsTraversalExtension {
+	return &NeighborsTraversalExtension{
+		NeighborsToken: traversalNeighborsToken,
+	}
+}
+
+// ScanIdent returns an associated graph token
+func (e *NeighborsTraversalExtension) ScanIdent(s string) (traversal.Token, bool) {
+	switch s {
+	case "NEIGHBORS":
+		return e.NeighborsToken, true
+	}
+	return traversal.IDENT, false
+}
+
+// ParseStep parses neighbors step
+func (e *NeighborsTraversalExtension) ParseStep(t traversal.Token, p traversal.GremlinTraversalContext) (traversal.GremlinTraversalStep, error) {
+	switch t {
+	case e.NeighborsToken:
+	default:
+		return nil, nil
+	}
+
+	maxDepth := int64(1)
+	edgeFilter, _ := topology.OwnershipMetadata().Filter()
+
+	switch len(p.Params) {
+	case 0:
+	default:
+		i := len(p.Params) / 2 * 2
+		filter, err := traversal.ParamsToFilter(filters.BoolFilterOp_OR, p.Params[:i]...)
+		if err != nil {
+			return nil, errors.Wrap(err, "Neighbors accepts an optional number of key/value tuples and an optional depth")
+		}
+		edgeFilter = filter
+
+		if i == len(p.Params) {
+			break
+		}
+
+		fallthrough
+	case 1:
+		depth, ok := p.Params[len(p.Params)-1].(int64)
+		if !ok {
+			return nil, errors.New("Neighbors last argument must be the maximum depth specified as an integer")
+		}
+		maxDepth = depth
+	}
+
+	return &NeighborsGremlinTraversalStep{context: p, maxDepth: maxDepth, edgeFilter: graph.NewElementFilter(edgeFilter)}, nil
+}
+
+// getNeighbors given a list of nodes, add them to the neighbors list, get the neighbors of that nodes and call this function with those new nodes
+func getNeighbors(g *graph.Graph, nodes []*graph.Node, neighbors *[]*graph.Node, currDepth, maxDepth int64, edgeFilter graph.ElementMatcher, visited map[graph.Identifier]bool) {
+	var newNodes []*graph.Node
+	for _, node := range nodes {
+		if _, ok := visited[node.ID]; !ok {
+			newNodes = append(newNodes, node)
+			visited[node.ID] = true
+		}
+	}
+	*neighbors = append(*neighbors, newNodes...)
+
+	if maxDepth == 0 || currDepth < maxDepth {
+		// For each node get its edges and nodes
+		for _, node := range newNodes {
+			// Get neighbors nodes, ignoring the ones already visited
+			parents := g.LookupNeighborIgnoreVisited(node, nil, edgeFilter, visited)
+			getNeighbors(g, parents, neighbors, currDepth+1, maxDepth, edgeFilter, visited)
+		}
+	}
+}
+
+// Exec Neighbors step
+func (d *NeighborsGremlinTraversalStep) Exec(last traversal.GraphTraversalStep) (traversal.GraphTraversalStep, error) {
+	var neighbors []*graph.Node
+
+	switch tv := last.(type) {
+	case *traversal.GraphTraversalV:
+		tv.GraphTraversal.RLock()
+		getNeighbors(tv.GraphTraversal.Graph, tv.GetNodes(), &neighbors, 0, d.maxDepth, d.edgeFilter, make(map[graph.Identifier]bool))
+		tv.GraphTraversal.RUnlock()
+
+		return traversal.NewGraphTraversalV(tv.GraphTraversal, neighbors), nil
+	}
+	return nil, traversal.ErrExecutionError
+}
+
+// Reduce Neighbors step
+func (d *NeighborsGremlinTraversalStep) Reduce(next traversal.GremlinTraversalStep) (traversal.GremlinTraversalStep, error) {
+	return next, nil
+}
+
+// Context Neighbors step
+func (d *NeighborsGremlinTraversalStep) Context() *traversal.GremlinTraversalContext {
+	return &d.context
+}

--- a/gremlin/traversal/neighbors.go
+++ b/gremlin/traversal/neighbors.go
@@ -167,7 +167,7 @@ func getNeighbors(g *graph.Graph, nodes []*graph.Node, maxDepth int64, edgeFilte
 
 					// Do not walk nodes already processed
 					if ok {
-						return
+						continue
 					}
 
 					// Append this node ID in the list of nodes to be visited in the next depth
@@ -184,8 +184,8 @@ func getNeighbors(g *graph.Graph, nodes []*graph.Node, maxDepth int64, edgeFilte
 	neighbors := make([]*graph.Node, 0, len(visitedNodes))
 	neighborsLock := sync.Mutex{}
 
-	wg.Add(len(visitedNodes))
 	for n := range visitedNodes {
+		wg.Add(1)
 		go func(nodeID graph.Identifier) {
 			defer wg.Done()
 

--- a/gremlin/traversal/neighbors_test.go
+++ b/gremlin/traversal/neighbors_test.go
@@ -1,0 +1,238 @@
+package traversal
+
+import (
+	"testing"
+
+	"github.com/skydive-project/skydive/graffiti/graph"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNeighbors(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		graphNodes    []*graph.Node
+		graphEdges    []*graph.Edge
+		originNodes   []*graph.Node
+		maxDepth      int64
+		edgeFilter    graph.ElementMatcher
+		expectedNodes []*graph.Node
+	}{
+		{
+			desc: "one graph node",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   0,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("A"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "interface connected to host and to other interface",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntA-IntB"),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   1,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "host connected to interface and that to other interface, depth 2",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntA-IntB"),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   2,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+		{
+			desc: "two hosts connected through interfaces, depth 3",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("HostB-IntB"),
+					graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntA-IntB"),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   3,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		}, {
+			desc: "two hosts connected through interfaces, reverse connection, depth 3",
+			graphNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			graphEdges: []*graph.Edge{
+				graph.CreateEdge(
+					graph.Identifier("HostA-IntA"),
+					graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("HostB-IntB"),
+					graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ownership"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+				graph.CreateEdge(
+					graph.Identifier("IntB-IntA"),
+					graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+					graph.Metadata{"RelationType": "ConnectsTo"},
+					graph.Unix(0, 0),
+					"",
+					"",
+				),
+			},
+			originNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+			maxDepth:   3,
+			edgeFilter: nil,
+			expectedNodes: []*graph.Node{
+				graph.CreateNode(graph.Identifier("HostA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntA"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("HostB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+				graph.CreateNode(graph.Identifier("IntB"), graph.Metadata{}, graph.Unix(0, 0), "", ""),
+			},
+		},
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			b, err := graph.NewMemoryBackend()
+			if err != nil {
+				t.Error(err.Error())
+			}
+			g := graph.NewGraph("testhost", b, "analyzer.testhost")
+
+			for _, n := range tC.graphNodes {
+				err := g.AddNode(n)
+				if err != nil {
+					t.Error(err.Error())
+				}
+			}
+
+			for _, e := range tC.graphEdges {
+				err := g.AddEdge(e)
+				if err != nil {
+					t.Error(err.Error())
+				}
+			}
+
+			neighbors := getNeighbors(g, tC.originNodes, tC.maxDepth, tC.edgeFilter)
+
+			assert.ElementsMatch(t, neighbors, tC.expectedNodes)
+
+		})
+	}
+}

--- a/gremlin/traversal/neighbors_test.go
+++ b/gremlin/traversal/neighbors_test.go
@@ -27,9 +27,19 @@ func (f *FakeNeighborsSlowGraphBackend) GetNode(i graph.Identifier, at graph.Con
 	return f.Backend.GetNode(i, at)
 }
 
+func (f *FakeNeighborsSlowGraphBackend) GetNodesFromIDs(i []graph.Identifier, at graph.Context) []*graph.Node {
+	time.Sleep(40 * time.Millisecond)
+	return f.Backend.GetNodesFromIDs(i, at)
+}
+
 func (f *FakeNeighborsSlowGraphBackend) GetNodeEdges(n *graph.Node, at graph.Context, m graph.ElementMatcher) []*graph.Edge {
 	time.Sleep(20 * time.Millisecond)
 	return f.Backend.GetNodeEdges(n, at, m)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodesEdges(n []*graph.Node, at graph.Context, m graph.ElementMatcher) []*graph.Edge {
+	time.Sleep(40 * time.Millisecond)
+	return f.Backend.GetNodesEdges(n, at, m)
 }
 
 func (f *FakeNeighborsSlowGraphBackend) EdgeAdded(e *graph.Edge) error {

--- a/gremlin/traversal/neighbors_test.go
+++ b/gremlin/traversal/neighbors_test.go
@@ -1,11 +1,68 @@
 package traversal
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/skydive-project/skydive/graffiti/graph"
 	"github.com/stretchr/testify/assert"
 )
+
+// FakeNeighborsSlowGraphBackend simulate a backend with history that could store different revisions of nodes
+type FakeNeighborsSlowGraphBackend struct {
+	Backend *graph.MemoryBackend
+}
+
+func (f *FakeNeighborsSlowGraphBackend) NodeAdded(n *graph.Node) error {
+	return f.Backend.NodeAdded(n)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) NodeDeleted(n *graph.Node) error {
+	return f.Backend.NodeDeleted(n)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNode(i graph.Identifier, at graph.Context) []*graph.Node {
+	time.Sleep(20 * time.Millisecond)
+	return f.Backend.GetNode(i, at)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodeEdges(n *graph.Node, at graph.Context, m graph.ElementMatcher) []*graph.Edge {
+	time.Sleep(20 * time.Millisecond)
+	return f.Backend.GetNodeEdges(n, at, m)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) EdgeAdded(e *graph.Edge) error {
+	return f.Backend.EdgeAdded(e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) EdgeDeleted(e *graph.Edge) error {
+	return f.Backend.EdgeDeleted(e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetEdge(i graph.Identifier, at graph.Context) []*graph.Edge {
+	return f.Backend.GetEdge(i, at)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetEdgeNodes(e *graph.Edge, at graph.Context, parentMetadata graph.ElementMatcher, childMetadata graph.ElementMatcher) ([]*graph.Node, []*graph.Node) {
+	return f.Backend.GetEdgeNodes(e, at, parentMetadata, childMetadata)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) MetadataUpdated(e interface{}) error {
+	return f.Backend.MetadataUpdated(e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetNodes(t graph.Context, m graph.ElementMatcher, e graph.ElementMatcher) []*graph.Node {
+	return f.Backend.GetNodes(t, m, e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) GetEdges(t graph.Context, m graph.ElementMatcher, e graph.ElementMatcher) []*graph.Edge {
+	return f.Backend.GetEdges(t, m, e)
+}
+
+func (f *FakeNeighborsSlowGraphBackend) IsHistorySupported() bool {
+	return f.Backend.IsHistorySupported()
+}
 
 func TestGetNeighbors(t *testing.T) {
 	testCases := []struct {
@@ -229,10 +286,74 @@ func TestGetNeighbors(t *testing.T) {
 				}
 			}
 
-			neighbors := getNeighbors(g, tC.originNodes, tC.maxDepth, tC.edgeFilter)
+			d := NeighborsGremlinTraversalStep{
+				maxDepth:   tC.maxDepth,
+				edgeFilter: tC.edgeFilter,
+			}
+			neighbors := d.getNeighbors(g, tC.originNodes)
 
 			assert.ElementsMatch(t, neighbors, tC.expectedNodes)
 
 		})
+	}
+}
+
+func BenchmarkGetNeighbors(b *testing.B) {
+	// Create graph with nodes and edges
+	backend, err := graph.NewMemoryBackend()
+	if err != nil {
+		b.Error(err.Error())
+	}
+
+	slowBackend := FakeNeighborsSlowGraphBackend{backend}
+	g := graph.NewGraph("testhost", &slowBackend, "analyzer.testhost")
+
+	parentNodes := 20
+
+	for n := 0; n < parentNodes; n++ {
+		node, err := g.NewNode(graph.Identifier(fmt.Sprintf("%d", n)), graph.Metadata{})
+		if err != nil {
+			b.Error(err.Error())
+		}
+
+		//  Childs of this node
+		for nc := 0; nc < 60; nc++ {
+			nodeChild, err := g.NewNode(graph.Identifier(fmt.Sprintf("%d-%d", n, nc)), graph.Metadata{})
+			if err != nil {
+				b.Error(err.Error())
+			}
+
+			_, err = g.NewEdge(graph.Identifier(fmt.Sprintf("%d-%d", n, nc)), node, nodeChild, graph.Metadata{})
+			if err != nil {
+				b.Error(err.Error())
+			}
+		}
+	}
+
+	// Each node connects with its next
+	nextNodeConnect := 5
+	for n := 0; n < parentNodes-nextNodeConnect; n++ {
+		for p := 1; p < nextNodeConnect; p++ {
+			// Connect interfaces
+			ifaceParentNode := g.GetNode(graph.Identifier(fmt.Sprintf("%d-%d", n, p)))
+			ifaceChildNode := g.GetNode(graph.Identifier(fmt.Sprintf("%d-%d", n+p, n)))
+
+			_, err = g.NewEdge(graph.Identifier(fmt.Sprintf("c-%d-%d", n, p)), ifaceParentNode, ifaceChildNode, graph.Metadata{})
+			if err != nil {
+				b.Error(err.Error())
+			}
+		}
+
+	}
+
+	// Using depth=8 we get a total of 798 neighbors
+	d := NeighborsGremlinTraversalStep{
+		maxDepth: 8,
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		d.getNeighbors(g, []*graph.Node{g.GetNode(graph.Identifier("1"))})
 	}
 }

--- a/gremlin/traversal/token.go
+++ b/gremlin/traversal/token.go
@@ -35,4 +35,5 @@ const (
 	traversalMoreThanToken    traversal.Token = 1013
 	traversalAscendantsToken  traversal.Token = 1014
 	traversalEventsToken      traversal.Token = 1015
+	traversalNeighborsToken   traversal.Token = 1016
 )

--- a/gremlin/traversal/token.go
+++ b/gremlin/traversal/token.go
@@ -34,4 +34,5 @@ const (
 	traversalGroupToken       traversal.Token = 1012
 	traversalMoreThanToken    traversal.Token = 1013
 	traversalAscendantsToken  traversal.Token = 1014
+	traversalEventsToken      traversal.Token = 1015
 )

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -179,6 +179,7 @@ func isGremlinExpr(v interface{}, param string) error {
 	tr.AddTraversalExtension(ge.NewAscendantsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewNextHopTraversalExtension())
 	tr.AddTraversalExtension(ge.NewGroupTraversalExtension())
+	tr.AddTraversalExtension(ge.NewEventsTraversalExtension())
 
 	if _, err := tr.Parse(strings.NewReader(query)); err != nil {
 		return GremlinNotValid(err)

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -177,6 +177,7 @@ func isGremlinExpr(v interface{}, param string) error {
 	tr.AddTraversalExtension(ge.NewRawPacketsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewDescendantsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewAscendantsTraversalExtension())
+	tr.AddTraversalExtension(ge.NewNeighborsTraversalExtension())
 	tr.AddTraversalExtension(ge.NewNextHopTraversalExtension())
 	tr.AddTraversalExtension(ge.NewGroupTraversalExtension())
 	tr.AddTraversalExtension(ge.NewEventsTraversalExtension())


### PR DESCRIPTION
Neighbor lo utilizamos para poder saltar desde un nodo a otros que tengan unas relaciones determinadas, con n grados de profundidad.

Una vez obtenidos los nodos usamos el step Events para agrupar los eventos que haya tenido durante un periodo determinado.

Se utilizan peticiones concurrentes al backend (Elasticsearch) para acelerar el tiempo de respuesta global de Skydive.

Cada commit explica con más detalle la implementación.